### PR TITLE
Tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ _testmain.go
 
 bin
 _work
-veneur
+/veneur

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -101,11 +101,8 @@ func main() {
 	parserChan := make(chan []byte)
 	for i := 0; i < veneur.Config.NumWorkers; i++ {
 		go func() {
-			for {
-				select {
-				case m := <-parserChan:
-					handlePacket(workers, m)
-				}
+			for m := range parserChan {
+				handlePacket(workers, m)
 			}
 		}()
 	}
@@ -120,9 +117,7 @@ func main() {
 			}).Error("Error reading from UDP")
 			continue
 		}
-		select {
-		case parserChan <- buf[:n]:
-		}
+		parserChan <- buf[:n] // TODO: termination condition for this channel?
 	}
 }
 
@@ -145,7 +140,5 @@ func handlePacket(workers []*veneur.Worker, packet []byte) {
 
 	// We're ready to have a worker process this packet, so add it
 	// to the work queue.
-	select {
-	case workers[index].WorkChan <- *m:
-	}
+	workers[index].WorkChan <- *m
 }

--- a/cmd/veneur/main.go
+++ b/cmd/veneur/main.go
@@ -60,7 +60,7 @@ func main() {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
-		}).Error("Error resolving address")
+		}).Fatal("Error resolving address")
 	}
 
 	serverConn, err := net.ListenUDP("udp", serverAddr)
@@ -68,7 +68,7 @@ func main() {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
-		}).Error("Error listening for UDP")
+		}).Fatal("Error listening for UDP")
 	}
 	serverConn.SetReadBuffer(veneur.Config.ReadBufferSizeBytes) // TODO Configurable!
 

--- a/samplers.go
+++ b/samplers.go
@@ -46,7 +46,7 @@ func (c *Counter) Sample(sample int32, sampleRate float32) {
 func (c *Counter) Flush() []DDMetric {
 	rate := float64(c.value) / Config.Interval.Seconds()
 	c.value = 0
-	return []DDMetric{DDMetric{
+	return []DDMetric{{
 		Name:       c.name,
 		Value:      [1][2]float64{{float64(time.Now().Unix()), rate}},
 		Tags:       c.tags,
@@ -80,7 +80,7 @@ func (g *Gauge) Sample(sample int32, sampleRate float32) {
 func (g *Gauge) Flush() []DDMetric {
 	v := g.value
 	g.value = 0
-	return []DDMetric{DDMetric{
+	return []DDMetric{{
 		Name:       g.name,
 		Value:      [1][2]float64{{float64(time.Now().Unix()), float64(v)}},
 		Tags:       g.tags,
@@ -131,7 +131,7 @@ func NewSet(name string, tags []string, setSize uint, accuracy float64) *Set {
 func (s *Set) Flush() []DDMetric {
 	v := s.value
 	s.value = 0
-	return []DDMetric{DDMetric{
+	return []DDMetric{{
 		Name:       s.name,
 		Value:      [1][2]float64{{float64(time.Now().Unix()), float64(v)}},
 		Tags:       s.tags,
@@ -176,7 +176,7 @@ func (h *Histo) Flush() []DDMetric {
 	now := float64(time.Now().Unix())
 	rate := float64(h.count) / Config.Interval.Seconds()
 	metrics := []DDMetric{
-		DDMetric{
+		{
 			Name:       fmt.Sprintf("%s.count", h.name),
 			Value:      [1][2]float64{{now, rate}},
 			Tags:       h.tags,
@@ -184,14 +184,14 @@ func (h *Histo) Flush() []DDMetric {
 			Hostname:   Config.Hostname,
 			Interval:   int32(Config.Interval.Seconds()),
 		},
-		DDMetric{
+		{
 			Name:       fmt.Sprintf("%s.max", h.name),
 			Value:      [1][2]float64{{now, float64(h.value.Max())}},
 			Tags:       h.tags,
 			MetricType: "gauge",
 			Hostname:   Config.Hostname,
 		},
-		DDMetric{
+		{
 			Name:       fmt.Sprintf("%s.min", h.name),
 			Value:      [1][2]float64{{now, float64(h.value.Min())}},
 			Tags:       h.tags,

--- a/samplers.go
+++ b/samplers.go
@@ -107,7 +107,7 @@ type Set struct {
 // the counter!
 func (s *Set) Sample(sample int32, sampleRate float32) {
 	byteSample := make([]byte, 4)
-	binary.PutVarint(byteSample, int64(sample))
+	binary.LittleEndian.PutUint32(byteSample, uint32(sample))
 	if !s.filter.Test(byteSample) {
 		s.filter.Add(byteSample)
 		s.value++

--- a/samplers_test.go
+++ b/samplers_test.go
@@ -75,8 +75,9 @@ func TestGauge(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-
-	s := NewSet("a.b.c", []string{"a:b"}, 1000, 0.99)
+	// remember, bloom filters can have false positives, so the test may be
+	// sensitive to the FP rate
+	s := NewSet("a.b.c", []string{"a:b"}, 1000, 0.0001)
 
 	assert.Equal(t, "a.b.c", s.name, "Name")
 	assert.Len(t, s.tags, 1, "Tag count")
@@ -88,6 +89,9 @@ func TestSet(t *testing.T) {
 
 	s.Sample(123, 1.0)
 
+	s.Sample(2147483647, 1.0)
+	s.Sample(-2147483648, 1.0)
+
 	metrics := s.Flush()
 	assert.Len(t, metrics, 1, "Flush")
 
@@ -97,7 +101,7 @@ func TestSet(t *testing.T) {
 	assert.Equal(t, "gauge", m1.MetricType, "Type")
 	assert.Len(t, m1.Tags, 1, "Tag count")
 	assert.Equal(t, "a:b", m1.Tags[0], "First tag")
-	assert.Equal(t, float64(2), m1.Value[0][1], "Value")
+	assert.Equal(t, float64(4), m1.Value[0][1], "Value")
 }
 
 func TestHisto(t *testing.T) {

--- a/worker.go
+++ b/worker.go
@@ -12,7 +12,7 @@ import (
 type Worker struct {
 	id         int
 	WorkChan   chan Metric
-	QuitChan   chan bool
+	QuitChan   chan struct{}
 	metrics    int64
 	counters   map[uint32]*Counter
 	gauges     map[uint32]*Gauge
@@ -27,7 +27,7 @@ func NewWorker(id int) *Worker {
 	return &Worker{
 		id:         id,
 		WorkChan:   make(chan Metric), // TODO Configurable!
-		QuitChan:   make(chan bool),
+		QuitChan:   make(chan struct{}),
 		metrics:    0,
 		counters:   make(map[uint32]*Counter),
 		gauges:     make(map[uint32]*Gauge),
@@ -181,7 +181,5 @@ func (w *Worker) Flush() []DDMetric {
 //
 // Note that the worker will only stop *after* it has finished its work.
 func (w *Worker) Stop() {
-	go func() {
-		w.QuitChan <- true
-	}()
+	close(w.QuitChan)
 }


### PR DESCRIPTION
various minor tweaks, most are nit-level (eg select with only one case).

Playground for varint encoding panic: https://play.golang.org/p/a0Q1vrACsM there are two ways we can fix this, we can encode as a varint into 5 byte buffer, or we can cast to a uint and encode to exactly 4 bytes every time. (There is no encoding function for signed int32 to 4 bytes.) I also had to tweak the test to capture the extreme values, because the false positive rate on the test was 99% and the filter was missing one of the values.