### PR TITLE
Switch to gohistogram and use float64s.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -14,7 +14,7 @@ import (
 type Metric struct {
 	Name       string
 	Digest     uint32
-	Value      int32
+	Value      float64
 	SampleRate float32
 	Type       string
 	Tags       []string
@@ -26,7 +26,7 @@ func ParseMetric(packet []byte) (*Metric, error) {
 	parts := bytes.SplitN(packet, []byte(":"), 2)
 
 	var metricName string
-	var metricValue int64
+	var metricValue float64
 	var metricType string
 	var metricTags []string
 	metricSampleRate := float64(1.0)
@@ -47,7 +47,7 @@ func ParseMetric(packet []byte) (*Metric, error) {
 		return nil, errors.New("Invalid metric packet, need at least 1 pipe for type")
 	}
 	// Now convert it
-	v, err := strconv.ParseInt(string(data[0]), 10, 32)
+	v, err := strconv.ParseFloat(string(data[0]), 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid integer for metric value: %s", parts[1])
 	}
@@ -96,5 +96,5 @@ func ParseMetric(packet []byte) (*Metric, error) {
 
 	digest := h.Sum32()
 
-	return &Metric{Name: metricName, Digest: digest, Value: int32(metricValue), Type: metricType, SampleRate: float32(metricSampleRate), Tags: metricTags}, nil
+	return &Metric{Name: metricName, Digest: digest, Value: float64(metricValue), Type: metricType, SampleRate: float32(metricSampleRate), Tags: metricTags}, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -11,7 +11,7 @@ func TestParser(t *testing.T) {
 	m, _ := ParseMetric([]byte("a.b.c:1|c"))
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, "a.b.c", m.Name, "Name")
-	assert.Equal(t, int32(1), m.Value, "Value")
+	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "counter", m.Type, "Type")
 }
 
@@ -20,7 +20,7 @@ func TestParserGauge(t *testing.T) {
 	m, _ := ParseMetric([]byte("a.b.c:1|g"))
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, "a.b.c", m.Name, "Name")
-	assert.Equal(t, int32(1), m.Value, "Value")
+	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "gauge", m.Type, "Type")
 }
 
@@ -29,7 +29,7 @@ func TestParserHistogram(t *testing.T) {
 	m, _ := ParseMetric([]byte("a.b.c:1|h"))
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, "a.b.c", m.Name, "Name")
-	assert.Equal(t, int32(1), m.Value, "Value")
+	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "histogram", m.Type, "Type")
 }
 
@@ -38,7 +38,7 @@ func TestParserTimer(t *testing.T) {
 	m, _ := ParseMetric([]byte("a.b.c:1|ms"))
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, "a.b.c", m.Name, "Name")
-	assert.Equal(t, int32(1), m.Value, "Value")
+	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "timer", m.Type, "Type")
 }
 
@@ -47,7 +47,7 @@ func TestParserSet(t *testing.T) {
 	m, _ := ParseMetric([]byte("a.b.c:1|s"))
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, "a.b.c", m.Name, "Name")
-	assert.Equal(t, int32(1), m.Value, "Value")
+	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "set", m.Type, "Type")
 }
 
@@ -56,7 +56,7 @@ func TestParserWithTags(t *testing.T) {
 	m, _ := ParseMetric([]byte("a.b.c:1|c|#foo:bar,baz:gorch"))
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, "a.b.c", m.Name, "Name")
-	assert.Equal(t, int32(1), m.Value, "Value")
+	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "counter", m.Type, "Type")
 	assert.Equal(t, 3, len(m.Tags), "# of Tags")
 
@@ -77,7 +77,7 @@ func TestParserWithSampleRate(t *testing.T) {
 	m, _ := ParseMetric([]byte("a.b.c:1|c|@0.1"))
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, "a.b.c", m.Name, "Name")
-	assert.Equal(t, int32(1), m.Value, "Value")
+	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "counter", m.Type, "Type")
 	assert.Equal(t, float32(0.1), m.SampleRate, "Sample Rate")
 
@@ -91,7 +91,7 @@ func TestParserWithSampleRateAndTags(t *testing.T) {
 	m, _ := ParseMetric([]byte("a.b.c:1|c|@0.1|#foo:bar,baz:gorch"))
 	assert.NotNil(t, m, "Got nil metric!")
 	assert.Equal(t, "a.b.c", m.Name, "Name")
-	assert.Equal(t, int32(1), m.Value, "Value")
+	assert.Equal(t, float64(1), m.Value, "Value")
 	assert.Equal(t, "counter", m.Type, "Type")
 	assert.Equal(t, float32(0.1), m.SampleRate, "Sample Rate")
 	assert.Len(t, m.Tags, 3, "Tags")


### PR DESCRIPTION
# Summary
Ditches the use of [gometrics](https://github.com/rcrowley/go-metrics)' `Histogram`  for [gohistogram](https://github.com/VividCortex/gohistogram) `NumericHistogram` which has a [nice summary article](https://www.vividcortex.com/blog/2013/07/08/streaming-approximate-histograms/). 

# Motivation

go-metrics was the first implementation I found and I trusted it due to a long history of using metrics-derived reservoir sampling. That instrumentation, however, requires `int`s. A quick check yielded the aforementioned blog post and simple implementation with `float64`. This removes the goofy requirement that veneur only deals with ints!

# Testing

All tests pass.

# Notes

* I also removed the unused `lastSampleTime` since that was an artifact of pre-flush-everything days.
* gohistogram does not track max and min, so I added that.

cc @tummychow